### PR TITLE
Add filters to WG User table output

### DIFF
--- a/wangguard-class-wp-users.php
+++ b/wangguard-class-wp-users.php
@@ -321,7 +321,7 @@ class WangGuard_Users_Table extends WP_List_Table {
 				$r .= '<td  width="25">' . $cell_contents . '</td>';
 			} else {
 				// Prepare cell classes
-				$classes = array( $column_name, 'column-' . $column_name, $style );
+				$classes = array( $column_name, 'column-' . $column_name );
 				if ( $column_name == 'posts' ) {
 					$classes[] = 'num';
 				}


### PR DESCRIPTION
Hi José-

I wanted to add some data to the WG Users table so I went through `WangGuard_Users_Table::single_row()` and added filter hooks for setting the row and cell classes as well as manipulating the content in each of the cells.

I did fix a couple of things along the way, like the class html output for the cells and the loop to output the BuddyPress groups, but this commit doesn't change the basic functionality. It mostly adds lots of filters.

Let me know if you have any questions or have any suggestions.

Thanks for all your work on WG.
